### PR TITLE
Allow to cache routes and views in console.

### DIFF
--- a/src/CKFinderServiceProvider.php
+++ b/src/CKFinderServiceProvider.php
@@ -14,6 +14,9 @@ class CKFinderServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->loadRoutesFrom(__DIR__.'/routes.php');
+        $this->loadViewsFrom(__DIR__.'/../views', 'ckfinder');
+
         if ($this->app->runningInConsole()) {
             $this->commands([CKFinderDownloadCommand::class]);
 
@@ -24,9 +27,6 @@ class CKFinderServiceProvider extends ServiceProvider
 
             return;
         }
-
-        $this->loadRoutesFrom(__DIR__.'/routes.php');
-        $this->loadViewsFrom(__DIR__.'/../views', 'ckfinder');
 
         $this->app->bind('ckfinder.connector', function() {
             if (!class_exists('\CKSource\CKFinder\CKFinder')) {


### PR DESCRIPTION
Fixes #22 and #29 when routes are not defined when running artisan command "route:cache" to cache routes.

Moved routes and views definitions before if statement as the routes and views definition was never reached if running commands like `php artisan route:cache` and `php artisan view:cache`.