### PR TITLE
Bkstar123 patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,69 @@ public function handle($request, Closure $next)
 Please have a look at the [CKFinder for PHP connector documentation](https://ckeditor.com/docs/ckfinder/ckfinder3-php/configuration.html#configuration_options_authentication) to find out
 more about this option.
 
+**Note**: 
+- Alternatively, You can set the configuration option ```$config['loadRoutes'] = false;``` in ```config/ckfinder.php```. Then, copy the routes in ```vendor/ckfinder/ckfinder-laravel-package/src/routes.php``` to your application routes such as ```routes/web.php``` to protect them with your Laravel auth middleware.  You must also prefix the controller namespace with backward slash so that Laravel will not prepend the default ```App\Http\Controllers```.  
+
+For example:  
+```php
+Route::any('/ckfinder/connector', '\CKSource\CKFinderBridge\Controller\CKFinderController@requestAction')
+    ->name('ckfinder_connector');
+
+Route::any('/ckfinder/browser', '\CKSource\CKFinderBridge\Controller\CKFinderController@browserAction')
+    ->name('ckfinder_browser');
+```
+
+- Disable Laravel CSRF protection for ```/ckfinder/*``` routes, as follows:  
+
+In **app/Http/Middleware/VerifyCsrfToken.php**, add:  
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+
+class VerifyCsrfToken extends Middleware
+{
+    /**
+     * Indicates whether the XSRF-TOKEN cookie should be set on the response.
+     *
+     * @var bool
+     */
+    protected $addHttpCookie = true;
+
+    /**
+     * The URIs that should be excluded from CSRF verification.
+     *
+     * @var array
+     */
+    protected $except = [
+        '/ckfinder/*'
+    ];
+}
+```
+The CkFinder connector has its own CSRF protection mechanism. You will also need to tell Laravel to not encrypt CKfinder's **ckCsrfToken** cookie, as follows:  
+
+In **app/Http/Middleware/EncryptCookies.php**:  
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Cookie\Middleware\EncryptCookies as Middleware;
+
+class EncryptCookies extends Middleware
+{
+    /**
+     * The names of the cookies that should not be encrypted.
+     *
+     * @var array
+     */
+    protected $except = [
+        'ckCsrfToken'
+    ];
+}
+```
 
 
 ## Configuration Options

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Please have a look at the [CKFinder for PHP connector documentation](https://cke
 more about this option.
 
 **Note**: 
-- Alternatively, You can set the configuration option ```$config['loadRoutes'] = false;``` in ```config/ckfinder.php```. Then, copy the routes in ```vendor/ckfinder/ckfinder-laravel-package/src/routes.php``` to your application routes such as ```routes/web.php``` to protect them with your Laravel auth middleware.  You must also prefix the controller namespace with backward slash so that Laravel will not prepend the default ```App\Http\Controllers```.  
+Alternatively, you can set the configuration option ```$config['loadRoutes'] = false;``` in ```config/ckfinder.php```. Then, copy the routes in ```vendor/ckfinder/ckfinder-laravel-package/src/routes.php``` to your application routes such as ```routes/web.php``` to protect them with your Laravel auth middleware.  You must also prefix the controller namespace with backward slash so that Laravel will not prepend the default ```App\Http\Controllers```.  
 
 For example:  
 ```php

--- a/src/CKFinderServiceProvider.php
+++ b/src/CKFinderServiceProvider.php
@@ -14,7 +14,9 @@ class CKFinderServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->loadRoutesFrom(__DIR__.'/routes.php');
+        if (config('ckfinder.loadRoutes')) {
+            $this->loadRoutesFrom(__DIR__.'/routes.php');
+        }
         $this->loadViewsFrom(__DIR__.'/../views', 'ckfinder');
 
         if ($this->app->runningInConsole()) {

--- a/src/config.php
+++ b/src/config.php
@@ -22,6 +22,8 @@
 
 $config = array();
 
+$config['loadRoutes'] = true;
+
 $config['authentication'] = '\CKSource\CKFinderBridge\CKFinderMiddleware';
 
 /*============================ License Key ============================================*/


### PR DESCRIPTION
Add a configuration option to allow disabling the default route definition. Then, users can copy the /ckfinder/* routes to their application route file such as routes/web.php and protect them under Laravel auth middleware (even  possibly use any existing authorization logic)