### PR TITLE
Added views publishing. Added publishing tags for config, assets ,views.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,22 @@ This repository contains the CKFinder 3 Package for Laravel 5.5+.
 3. Publish the CKFinder connector configuration and assets.
 
     ```bash
-    php artisan vendor:publish --tag=ckfinder
+    php artisan vendor:publish --tag=ckfinder-assets --tag=ckfinder-config
     ```
 
     This will publish CKFinder assets to `public/js/ckfinder`, and the CKFinder connector configuration to `config/ckfinder.php`.
+    
+    You can also publish the views used by this package in case you need custom route names, different assets location, file browser customization etc.
+    
+    ```bash
+    php artisan vendor:publish --tag=ckfinder-views
+    ```
+    
+    Finally, you can publish package's configuration, assets and views using only one command.
+    
+    ```bash
+    php artisan vendor:publish --tag=ckfinder
+    ```
 
 4. Create a directory for CKFinder files and allow for write access to it. By default CKFinder expects the files to be placed in `public/userfiles` (this can be altered in the configuration).
 

--- a/src/CKFinderServiceProvider.php
+++ b/src/CKFinderServiceProvider.php
@@ -23,9 +23,17 @@ class CKFinderServiceProvider extends ServiceProvider
             $this->commands([CKFinderDownloadCommand::class]);
 
             $this->publishes([
-                __DIR__.'/config.php' => config_path('ckfinder.php'),
+                __DIR__.'/config.php' => config_path('ckfinder.php')
+            ], ['ckfinder', 'ckfinder-config']);
+
+            $this->publishes([
                 __DIR__.'/../public' => public_path('js')
-            ], 'ckfinder');
+            ], ['ckfinder', 'ckfinder-assets']);
+
+            $this->publishes([
+                __DIR__.'/../views/setup.blade.php' => resource_path('views/vendor/ckfinder/setup.blade.php'),
+                __DIR__.'/../views/browser.blade.php' => resource_path('views/vendor/ckfinder/browser.blade.php')
+            ], ['ckfinder', 'ckfinder-views']);
 
             return;
         }

--- a/views/browser.blade.php
+++ b/views/browser.blade.php
@@ -11,7 +11,7 @@ For licensing, see LICENSE.html or https://ckeditor.com/sales/license/ckfinder
 </head>
 <body>
 
-<?php include __DIR__.'/setup.php' ?>
+@include('ckfinder::setup')
 
 <script>
 	CKFinder.start();

--- a/views/setup.blade.php
+++ b/views/setup.blade.php
@@ -1,0 +1,2 @@
+<script type="text/javascript" src="{{ asset('js/ckfinder/ckfinder.js') }}"></script>
+<script>CKFinder.config( { connectorPath: @json(route('ckfinder_connector')) } );</script>

--- a/views/setup.php
+++ b/views/setup.php
@@ -1,2 +1,0 @@
-<script type="text/javascript" src="<?php echo asset('js/ckfinder/ckfinder.js') ?>"></script>
-<script>CKFinder.config( { connectorPath: <?php echo json_encode(route('ckfinder_connector')) ?> } );</script>


### PR DESCRIPTION
Fixes #49. Added views for publishing. Added separate publishing tags for config, assets and views. Added common publishing tag to be able to publish all at once. Converted views to blade to support blade vendor syntax for both `browser` and `setup` (before the PR, the `setup` view was included using php's `include` that caused the `setup` customization not to work in `browser` view without customizing it too). Updated README to reflect the changes.