### PR TITLE
Updated support to Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6.0",
-        "laravel/framework": "^5.5|^6.20.42|^7.0|^8.0",
+        "laravel/framework": "^5.5|^6.20.42|^7.0|^8.0|^9.0",
         "pimple/pimple": "~3.0",
         "league/flysystem": "^1.1.8",
         "league/flysystem-aws-s3-v3": "^1.0.13",


### PR DESCRIPTION
Main ckfinder/ckfinder-laravel-package is not supporting Laravel 9 and it is not updated from Dec 2021 so created this request to update support to Laravel 9